### PR TITLE
added dev-python/twisted-web dependency

### DIFF
--- a/www-client/torbrowser-launcher/torbrowser-launcher-0.0.3.ebuild
+++ b/www-client/torbrowser-launcher/torbrowser-launcher-0.0.3.ebuild
@@ -20,7 +20,8 @@ IUSE=""
 
 DEPEND="${PYTHON_DEPS}
 	dev-python/pygtk[${PYTHON_USEDEP}]
-	dev-python/twisted-core[${PYTHON_USEDEP}]"
+	dev-python/twisted-core[${PYTHON_USEDEP}]
+	dev-python/twisted-web[${PYTHON_USEDEP}]"
 RDEPEND="${DEPEND}
 	app-crypt/gnupg
 	dev-python/psutil[${PYTHON_USEDEP}]


### PR DESCRIPTION
Fresh install left me with ImportError: No module named web.client
Fixed by installing dev-python/twisted-web
