### PR TITLE
Fix the ebuild 'python_gen_cond_dep' syntax

### DIFF
--- a/www-client/torbrowser-launcher/torbrowser-launcher-0.3.2.ebuild
+++ b/www-client/torbrowser-launcher/torbrowser-launcher-0.3.2.ebuild
@@ -18,12 +18,12 @@ KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 RDEPEND="${PYTHON_DEPS}
-	$(python_gen_cond_dep '
-		app-crypt/gpgme[python,${PYTHON_MULTI_USEDEP}]
+	$(python_gen_cond_dep \
+	'	app-crypt/gpgme[python,${PYTHON_MULTI_USEDEP}]
 		dev-python/PyQt5[${PYTHON_MULTI_USEDEP}]
 		dev-python/PySocks[${PYTHON_MULTI_USEDEP}]
 		dev-python/requests[${PYTHON_MULTI_USEDEP}]
-	')"
+	' python3*)"
 DEPEND="${PYTHON_DEPS}"
 
 python_install_all() {


### PR DESCRIPTION
'_python_impl_matches: takes at least 2 parameters'

just added the missing parameter.