### PR TITLE
www-client/torbrowser-launcher: python 10 support patch

### DIFF
--- a/www-client/torbrowser-launcher/files/torbrowser-launcher-0.3.5-py10.patch
+++ b/www-client/torbrowser-launcher/files/torbrowser-launcher-0.3.5-py10.patch
@@ -1,0 +1,24 @@
+From 64c73c9854efd531d393e98e92a69085dd22a253 Mon Sep 17 00:00:00 2001
+From: meehow <michal@ert.pl>
+Date: Fri, 22 Apr 2022 02:39:46 +0200
+Subject: [PATCH] gui.move accepts only integers
+
+---
+ torbrowser_launcher/__init__.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/torbrowser_launcher/__init__.py b/torbrowser_launcher/__init__.py
+index bff3e8e..115fd4f 100644
+--- a/torbrowser_launcher/__init__.py
++++ b/torbrowser_launcher/__init__.py
+@@ -90,8 +90,8 @@ def main():
+     desktop = app.desktop()
+     window_size = gui.size()
+     gui.move(
+-        (desktop.width() - window_size.width()) / 2,
+-        (desktop.height() - window_size.height()) / 2,
++        (desktop.width() - window_size.width()) // 2,
++        (desktop.height() - window_size.height()) // 2,
+     )
+     gui.show()
+ 

--- a/www-client/torbrowser-launcher/torbrowser-launcher-0.3.5-r1.ebuild
+++ b/www-client/torbrowser-launcher/torbrowser-launcher-0.3.5-r1.ebuild
@@ -1,0 +1,74 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_SETUPTOOLS=no
+PYTHON_COMPAT=( python3_{8..10} )
+
+inherit distutils-r1 optfeature xdg
+
+DESCRIPTION="A program to download, updated, and run the Tor Browser Bundle"
+HOMEPAGE="https://github.com/micahflee/torbrowser-launcher"
+SRC_URI="https://github.com/micahflee/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="apparmor"
+
+FIREFOX_BIN="dev-libs/atk
+	dev-libs/dbus-glib
+	>=dev-libs/glib-2.26:2
+	media-libs/fontconfig
+	>=media-libs/freetype-2.4.10
+	sys-apps/dbus
+	virtual/freedesktop-icon-theme
+	>=x11-libs/cairo-1.10[X]
+	x11-libs/gdk-pixbuf
+	>=x11-libs/gtk+-3.11:3[wayland]
+	x11-libs/libxcb
+	x11-libs/libX11
+	x11-libs/libXcomposite
+	x11-libs/libXcursor
+	x11-libs/libXdamage
+	x11-libs/libXext
+	x11-libs/libXfixes
+	x11-libs/libXi
+	x11-libs/libXrender
+	x11-libs/libXt
+	>=x11-libs/pango-1.22.0"
+
+DEPEND="${PYTHON_DEPS}
+	dev-python/distro[${PYTHON_USEDEP}]"
+
+RDEPEND="${PYTHON_DEPS}
+	${FIREFOX_BIN}
+	app-crypt/gpgme[python,${PYTHON_USEDEP}]
+	dev-python/packaging[${PYTHON_USEDEP}]
+	dev-python/PyQt5[${PYTHON_USEDEP},widgets]
+	dev-python/PySocks[${PYTHON_USEDEP}]
+	dev-python/distro[${PYTHON_USEDEP}]
+	dev-python/packaging[${PYTHON_USEDEP}]
+	dev-python/requests[${PYTHON_USEDEP}]
+	apparmor? ( sys-libs/libapparmor )
+	!www-client/torbrowser"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-py10.patch
+)
+
+python_install_all() {
+	distutils-r1_python_install_all
+
+	# delete apparmor profiles
+	if ! use apparmor; then
+		rm -r "${D}/etc/apparmor.d" || die "Failed to remove apparmor profiles"
+		rmdir "${D}/etc" || die "Failed to remove empty directory"
+	fi
+}
+
+pkg_postinst() {
+	xdg_pkg_postinst
+	optfeature "updating over system Tor" net-vpn/tor dev-python/txsocksx
+}


### PR DESCRIPTION
patch taken from: https://github.com/micahflee/torbrowser-launcher/pull/635

tested on python 3.10.4

fixes following error: 

> 
> 
> Traceback (most recent call last):
>   File "/usr/lib/python-exec/python3.10/torbrowser-launcher", line 30, in <module>
>     torbrowser_launcher.main()
>   File "/usr/lib/python3.10/site-packages/torbrowser_launcher/__init__.py", line 92, in main
>     gui.move(
> TypeError: arguments did not match any overloaded call:
>   move(self, QPoint): argument 1 has unexpected type 'float'
>   move(self, int, int): argument 1 has unexpected type 'float'