### PR TITLE
Fix Python Deps for torbrowser-launcher

### DIFF
--- a/www-client/torbrowser-launcher/torbrowser-launcher-0.3.7-r1.ebuild
+++ b/www-client/torbrowser-launcher/torbrowser-launcher-0.3.7-r1.ebuild
@@ -46,8 +46,8 @@ RDEPEND="${PYTHON_DEPS}
 	${FIREFOX_BIN}
 	app-crypt/gpgme[python,${PYTHON_USEDEP}]
 	dev-python/packaging[${PYTHON_USEDEP}]
-	dev-python/PyQt5[${PYTHON_USEDEP},widgets]
-	dev-python/PySocks[${PYTHON_USEDEP}]
+	dev-python/pyqt5[${PYTHON_USEDEP},widgets]
+	dev-python/pysocks[${PYTHON_USEDEP}]
 	dev-python/distro[${PYTHON_USEDEP}]
 	dev-python/packaging[${PYTHON_USEDEP}]
 	dev-python/requests[${PYTHON_USEDEP}]


### PR DESCRIPTION
There have been a few renames in the gentoo repo regarding some python packages. Two of them affect the torbrowser-launcher ebuild. This pull request will make the dependencies follow the rename.

For reference see:
https://gitweb.gentoo.org/repo/gentoo.git/commit/dev-python/pyqt5?id=37d48fa129706f33aff087d4d599a2b16114ef14
https://gitweb.gentoo.org/repo/gentoo.git/commit/dev-python/pysocks?id=41dd7bb0aa6083c8f0056ce2f80e1abcfa0e15ad