### PR TITLE
www-client/torbrowser: don't use --disable-eme on aarch64

### DIFF
--- a/www-client/torbrowser/torbrowser-128.12.0_p14504.ebuild
+++ b/www-client/torbrowser/torbrowser-128.12.0_p14504.ebuild
@@ -489,7 +489,11 @@ src_configure() {
 	mozconfig_use_enable dbus
 	mozconfig_add_options_ac ''  --disable-libproxy
 
-	mozconfig_add_options_ac '' --disable-eme
+	CARCH=${CHOST%%-*}
+	case "$CARCH" in
+		aarch64) einfo "--disable-eme not supported on aarch64";;
+		*) mozconfig_add_options_ac '' --disable-eme
+	esac
 
 	if use hardened ; then
 		mozconfig_add_options_ac "+hardened" --enable-hardening


### PR DESCRIPTION
The `--disable-eme` flag caused issues when compiling torbrowser on arm64. It would error with:

```
 0:00.59 checking for _Unwind_Backtrace... yes
 0:00.59 Traceback (most recent call last):
 0:00.59   File "/var/tmp/portage/www-client/torbrowser-128.12.0_p14504/work/firefox-tor-browser-128.12.0esr-14.5-1-build1/configure.py", line 351, in <module>
 0:00.59     sys.exit(main(sys.argv))
 0:00.59              ~~~~^^^^^^^^^^
 0:00.59   File "/var/tmp/portage/www-client/torbrowser-128.12.0_p14504/work/firefox-tor-browser-128.12.0esr-14.5-1-build1/configure.py", line 141, in main
 0:00.59     sandbox.run()
 0:00.59     ~~~~~~~~~~~^^
 0:00.59   File "/var/tmp/portage/www-client/torbrowser-128.12.0_p14504/work/firefox-tor-browser-128.12.0esr-14.5-1-build1/python/mozbuild/mozbuild/configure/__init__.py", line 522, in run
 0:00.59     self._value_for(option)
 0:00.59     ~~~~~~~~~~~~~~~^^^^^^^^
 0:00.59   File "/var/tmp/portage/www-client/torbrowser-128.12.0_p14504/work/firefox-tor-browser-128.12.0esr-14.5-1-build1/python/mozbuild/mozbuild/configure/__init__.py", line 627, in _value_for
 0:00.59     return self._value_for_option(obj)
 0:00.59            ~~~~~~~~~~~~~~~~~~~~~~^^^^^
 0:00.59   File "/var/tmp/portage/www-client/torbrowser-128.12.0_p14504/work/firefox-tor-browser-128.12.0esr-14.5-1-build1/python/mozbuild/mozbuild/util.py", line 911, in method_call
 0:00.59     cache[args] = self.func(instance, *args)
 0:00.59                   ~~~~~~~~~^^^^^^^^^^^^^^^^^
 0:00.59   File "/var/tmp/portage/www-client/torbrowser-128.12.0_p14504/work/firefox-tor-browser-128.12.0esr-14.5-1-build1/python/mozbuild/mozbuild/configure/__init__.py", line 694, in _value_for_option
 0:00.59     raise InvalidOptionError(
 0:00.59     ...<2 lines>...
 0:00.59     )
 0:00.59 mozbuild.configure.options.InvalidOptionError: --disable-eme is not available in this configuration
```

Without setting the flag I was able to compile it.
