### PR TITLE
www-client/torbrowser-launcher: adapt to split gpgme

### DIFF
--- a/www-client/torbrowser-launcher/torbrowser-launcher-0.3.7-r2.ebuild
+++ b/www-client/torbrowser-launcher/torbrowser-launcher-0.3.7-r2.ebuild
@@ -44,7 +44,7 @@ DEPEND="${PYTHON_DEPS}
 
 RDEPEND="${PYTHON_DEPS}
 	${FIREFOX_BIN}
-	app-crypt/gpgme[python,${PYTHON_USEDEP}]
+	dev-python/gpgmepy[${PYTHON_USEDEP}]
 	dev-python/packaging[${PYTHON_USEDEP}]
 	dev-python/pyqt5[${PYTHON_USEDEP},widgets]
 	dev-python/pysocks[${PYTHON_USEDEP}]


### PR DESCRIPTION
gpgme got its bindings split into separate packages, there is also a porting aid for the older version you can just do `dev-python/gpgmepy[${PYTHON_USEDEP}]`

Example: https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=f53dacaf0bf2e117c0e1efadab3880bc588e650e

```
WARNING: One or more updates/rebuilds have been skipped due to a dependency conflict:

app-crypt/gpgme:1

  (app-crypt/gpgme-2.0.0:1/45.0::gentoo, ebuild scheduled for merge) USE="verify-sig -common-lisp -static-libs -test" ABI_X86="(64)" conflicts with
    app-crypt/gpgme[python,python_targets_python3_13(-)] required by (www-client/torbrowser-launcher-0.3.7-r1:0/0::torbrowser, installed) USE="" ABI_X86="(64)" PYTHON_TARGETS="python3_13 -python3_11 -python3_12"
```