### PR TITLE
Some test fixes.

### DIFF
--- a/app-misc/mat2/files/mat2-0.14.0-fix-tests.patch
+++ b/app-misc/mat2/files/mat2-0.14.0-fix-tests.patch
@@ -1,0 +1,93 @@
+Backport test fixes to deal with smaller terminal sizes.
+Preemptively backport a py3.15 test fix as its backwards compatible.
+
+https://github.com/jvoisin/mat2/issues/26
+https://github.com/jvoisin/mat2/commit/690e01d475117a4e0c85f26154b26ef332f036be
+
+From 690e01d475117a4e0c85f26154b26ef332f036be Mon Sep 17 00:00:00 2001
+From: jvoisin <julien.voisin@dustri.org>
+Date: Fri, 21 Nov 2025 16:59:32 +0100
+Subject: [PATCH] Improve the testsuite's portability
+
+Small terminal sizes might split the cli's help message on odd places.
+
+This should close #26
+--- a/tests/test_climat2.py
++++ b/tests/test_climat2.py
+@@ -24,9 +24,11 @@ def test_help(self):
+         self.assertIn(b'mat2 [-h] [-V]', stdout)
+         self.assertIn(b'[--unknown-members policy]', stdout)
+         self.assertIn(b'[--inplace]', stdout)
+-        self.assertIn(b' [-v] [-l]', stdout)
++        self.assertIn(b'[-v]', stdout)
++        self.assertIn(b'[-l]', stdout)
+         self.assertIn(b'[--check-dependencies]', stdout)
+-        self.assertIn(b'[-L | -s]', stdout)
++        self.assertIn(b'[-L', stdout)
++        self.assertIn(b'-s]', stdout)
+         self.assertIn(b'[files ...]', stdout)
+ 
+     def test_no_arg(self):
+@@ -35,10 +37,11 @@ def test_no_arg(self):
+         self.assertIn(b'mat2 [-h] [-V]', stdout)
+         self.assertIn(b'[--unknown-members policy]', stdout)
+         self.assertIn(b'[--inplace]', stdout)
+-        self.assertIn(b' [-v]', stdout)
++        self.assertIn(b'[-v]', stdout)
+         self.assertIn(b'[-l]', stdout)
+         self.assertIn(b'[--check-dependencies]', stdout)
+-        self.assertIn(b'[-L | -s]', stdout)
++        self.assertIn(b'[-L', stdout)
++        self.assertIn(b'-s]', stdout)
+         self.assertIn(b'[files ...]', stdout)
+ 
+
+https://github.com/jvoisin/mat2/pull/30
+https://github.com/jvoisin/mat2/commit/05f34a17695be65b1ad9782911f87e000de8fc8b
+
+From 05f34a17695be65b1ad9782911f87e000de8fc8b Mon Sep 17 00:00:00 2001
+From: Emir Akdag <infraw.linux@proton.me>
+Date: Sun, 21 Dec 2025 20:54:26 +0300
+Subject: [PATCH] Fix test_climat2 failure on Python 3.15
+
+Python 3.15 changed argparse output formatting by removing brackets
+around options.
+
+Relax the assertions to ensure compatibility with both old and new
+Python versions.
+--- a/tests/test_climat2.py
++++ b/tests/test_climat2.py
+@@ -24,12 +24,12 @@ def test_help(self):
+         self.assertIn(b'mat2 [-h] [-V]', stdout)
+         self.assertIn(b'[--unknown-members policy]', stdout)
+         self.assertIn(b'[--inplace]', stdout)
+-        self.assertIn(b'[-v]', stdout)
+-        self.assertIn(b'[-l]', stdout)
+-        self.assertIn(b'[--check-dependencies]', stdout)
++        self.assertIn(b'-v', stdout)
++        self.assertIn(b'-l', stdout)
++        self.assertIn(b'--check-dependencies', stdout)
+         self.assertIn(b'[-L', stdout)
+         self.assertIn(b'-s]', stdout)
+-        self.assertIn(b'[files ...]', stdout)
++        self.assertIn(b'files', stdout)
+ 
+     def test_no_arg(self):
+         proc = subprocess.Popen(mat2_binary, stdout=subprocess.PIPE)
+@@ -37,12 +37,12 @@ def test_no_arg(self):
+         self.assertIn(b'mat2 [-h] [-V]', stdout)
+         self.assertIn(b'[--unknown-members policy]', stdout)
+         self.assertIn(b'[--inplace]', stdout)
+-        self.assertIn(b'[-v]', stdout)
+-        self.assertIn(b'[-l]', stdout)
+-        self.assertIn(b'[--check-dependencies]', stdout)
++        self.assertIn(b'-v', stdout)
++        self.assertIn(b'-l', stdout)
++        self.assertIn(b'--check-dependencies', stdout)
+         self.assertIn(b'[-L', stdout)
+         self.assertIn(b'-s]', stdout)
+-        self.assertIn(b'[files ...]', stdout)
++        self.assertIn(b'files', stdout)
+ 
+ 
+ class TestVersion(unittest.TestCase):

--- a/app-misc/mat2/mat2-0.14.0.ebuild
+++ b/app-misc/mat2/mat2-0.14.0.ebuild
@@ -28,6 +28,7 @@ RDEPEND="
 "
 BDEPEND="
 	test? (
+		gui-libs/gdk-pixbuf-loader-webp
 		media-libs/exiftool:*
 		media-video/ffmpeg[lame,vorbis]
 		x11-libs/gdk-pixbuf:2[introspection,jpeg,tiff]
@@ -38,13 +39,9 @@ DOCS=( doc {CHANGELOG,CONTRIBUTING,INSTALL,README}.md )
 
 distutils_enable_tests unittest
 
-src_test() {
-	# Double sandboxing is not possible
-	if ! has usersandbox ${FEATURES}; then
-		distutils-r1_src_test
-	fi
-	return 0
-}
+PATCHES=(
+	"${FILESDIR}"/mat2-0.14.0-fix-tests.patch
+)
 
 pkg_postinst() {
 	optfeature "misc file format support" media-libs/exiftool

--- a/app-misc/metadata-cleaner/metadata-cleaner-4.0.0.ebuild
+++ b/app-misc/metadata-cleaner/metadata-cleaner-4.0.0.ebuild
@@ -16,6 +16,10 @@ SLOT="0"
 KEYWORDS="~amd64"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
+# Tests aren't relevant downstream (codequality).
+# Opportunistically use pre-commit and fail without a git repository.
+RESTRICT="test"
+
 DEPEND="${PYTHON_DEPS}
 	dev-util/itstool
 	gui-libs/gtk:4


### PR DESCRIPTION
I was haphazardly running tests for any revdep of pygobject. Your repo caught my interest as app-misc/metadata-cleaner failed.

```
>>> Test phase: app-misc/metadata-cleaner-4.0.0
meson test --print-errorlogs --num-processes 12
ninja: Entering directory `/var/tmp/portage/app-misc/metadata-cleaner-4.0.0/work/metadata-cleaner-4.0.0-build'
ninja: Jobserver mode detected: --jobserver-auth=fifo:/dev/steve
ninja: no work to do.
[1-4/4] 🌑 metadata-cleaner:Check typing, code style, docstrings, reuse                 0/30s^M1/4 metadata-cleaner:Validate desktop file                              OK              0.03s
2/4 metadata-cleaner:Validate schema file                               OK              0.02s
[3-4/4] 🌒 metadata-cleaner:Check typing, code style, docstrings, reuse                 0/30s^M3/4 metadata-cleaner:Validate appstream file                            OK              0.02s
[4/4] 🌓 metadata-cleaner:Check typing, code style, docstrings, reuse                   0/30s^M4/4 metadata-cleaner:Check typing, code style, docstrings, reuse        FAIL            0.20s   exit status 1
>>> MALLOC_PERTURB_=57 ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1 MSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 MESON_TEST_ITERATION=1 UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 /usr/bin/pre-commit run --all-files
 ✀  
An error has occurred: FatalError: git failed. Is it installed, and are you in a Git repository directory?
Check the log at /var/tmp/portage/app-misc/metadata-cleaner-4.0.0/homedir/.cache/pre-commit/pre-commit.log



Summary of Failures:

4/4 metadata-cleaner:Check typing, code style, docstrings, reuse FAIL            0.20s   exit status 1

Ok:                3   
Fail:              1   

Full log written to /var/tmp/portage/app-misc/metadata-cleaner-4.0.0/work/metadata-cleaner-4.0.0-build/meson-logs/testlog.txt
```

Restricted that as the tests dont do anything interesting.

As a bonus looked into app-misc/mat2. 